### PR TITLE
Changed Default Icon for Search + Added props

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ const userList = {
   rowBackgroundColor={"#eee"}
   rowHeight={40}
   rowRadius={5}
-	searchIconName="ios-checkmark"
-	searchIconColor="red"
-	searchIconSize={30}
+  searchIconName="ios-checkmark"
+  searchIconColor="red"
+  searchIconSize={30}
   iconColor={"#00a2dd"}
   iconSize={30}
   selectedIconName={"ios-checkmark-circle-outline"}
@@ -60,9 +60,9 @@ const userList = {
 | rowBackgroundColor | String | background color for each row in list |
 | rowHeight | Integer | row height |
 | rowRadius | Integer | row border radius |
-| seearchIconName | String | Name of the vector icon displayed on the search bar |
-| seearchIconSize | Integer | icon size for the icon displayed on the search bar |
-| seearchIconColor | String | icon color the icon displayed on the search bar |
+| searchIconName | String | Name of the vector icon displayed on the search bar |
+| searchIconSize | Integer | icon size for the icon displayed on the search bar |
+| searchIconColor | String | icon color the icon displayed on the search bar |
 | iconSize | Integer | icon size for checked/unchecked icons |
 | iconColor | String | icon color for checked/unchecked icons and search icon also border color of search bar |
 | iconSize | Integer | icon size for checked/unchecked icons |

--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ const userList = {
   rowBackgroundColor={"#eee"}
   rowHeight={40}
   rowRadius={5}
+	searchIconName="ios-checkmark"
+	searchIconColor="red"
+	searchIconSize={30}
   iconColor={"#00a2dd"}
   iconSize={30}
   selectedIconName={"ios-checkmark-circle-outline"}
   unselectedIconName={"ios-radio-button-off-outline"}
   scrollViewHeight={130}
-  selected={[1,2]} // list of options which are selected by default
+  selected={[223, 125]} // list of options which are selected by default
 />
 ```
 
@@ -57,6 +60,10 @@ const userList = {
 | rowBackgroundColor | String | background color for each row in list |
 | rowHeight | Integer | row height |
 | rowRadius | Integer | row border radius |
+| seearchIconName | String | Name of the vector icon displayed on the search bar |
+| seearchIconSize | Integer | icon size for the icon displayed on the search bar |
+| seearchIconColor | String | icon color the icon displayed on the search bar |
+| iconSize | Integer | icon size for checked/unchecked icons |
 | iconColor | String | icon color for checked/unchecked icons and search icon also border color of search bar |
 | iconSize | Integer | icon size for checked/unchecked icons |
 | selectedIconName | String | selected/checked icon name (react-native-vector-icons/Ionicon) |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const userList = {
   selectedIconName={"ios-checkmark-circle-outline"}
   unselectedIconName={"ios-radio-button-off-outline"}
   scrollViewHeight={130}
-  selected={[223, 125]} // list of options which are selected by default
+  selected={["Tom", "Christin"]} // list of options which are selected by default
 />
 ```
 

--- a/multipleSelect.js
+++ b/multipleSelect.js
@@ -105,7 +105,7 @@ export default class CustomMultiPicker extends Component {
       <View onLayout={(evt)=>{this.getNewDimensions(evt)}}>
         {this.props.search && <View style={{ flexDirection: 'row', height: 55 }}>
           <View style={{ marginTop: 15, marginLeft: 15, backgroundColor: 'transparent' }}>
-            <Icon name="ios-search-outline" color={this.props.iconColor} size={25}/>
+            <Icon name={this.props.searchIconName || "ios-search"} color={this.props.searchIconColor || this.props.iconColor} size={this.props.searchIconSize || this.props.iconSize || 25} />
           </View>
           <TextInput
             style={{


### PR DESCRIPTION
This fork has a fix for the issue: https://github.com/atasmohammadi/react-native-multiple-select-list/issues/18

Old Code: 
<Icon name="ios-search-outline" color={this.props.iconColor} size={25}/>

New Code: 
<Icon name={this.props.searchIconName || "ios-search"} color={this.props.searchIconColor || this.props.iconColor} size={this.props.searchIconSize || this.props.iconSize || 25} />

In effect, 
1. The default icon for search is changed from "ios-search-outline" to "ios-search". The old one "ios-search-outline" is giving a warning with expo, and an (?) is displayed as s search icon! 
2. There is a new optional prop (searchIconName) for the search icon name. 
3. There is a new optional prop (searchIconColor) for the search icon size. 
4. There is a new optional prop (searchIconSize) for the search icon size.